### PR TITLE
Downgrade github.com/zclconf/go-cty to 1.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/diskfs/go-diskfs v1.2.0
 	github.com/hashicorp/hcl/v2 v2.14.0
 	github.com/hashicorp/packer-plugin-sdk v0.3.2
-	github.com/zclconf/go-cty v1.11.0
+	github.com/zclconf/go-cty v1.10.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -558,9 +558,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
-github.com/zclconf/go-cty v1.11.0 h1:726SxLdi2SDnjY+BStqB9J1hNp4+2WlzyXLuimibIe0=
-github.com/zclconf/go-cty v1.11.0/go.mod h1:s9IfD1LK5ccNMSWCVFCE2rJfHiZgi7JijgeWIMfhLvA=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=


### PR DESCRIPTION
`github.com/zclconf/go-cty` package [introduced a breaking change in it's `1.11.0` release](https://github.com/zclconf/go-cty/commit/97bafac0dea33a3f74db88ab54dea2937b9e8aef) which breaks communication with endpoints using older versions of that package, namely, Packer: https://github.com/hashicorp/packer/pull/11954.

If you will try to build `packer-plugin-tart` manually and use it, the following exception will be thrown:

```
2022/09/15 09:42:07 packer-plugin-tart plugin: 2022/09/15 09:42:07 Waiting for connection...
2022/09/15 09:42:07 Received unix RPC address for /Users/edi/.packer.d/plugins/packer-plugin-tart: addr is /var/folders/tg/9y32_b7x4_sgg69j691gq_wh0000gn/T/packer-plugin1520519980
2022/09/15 09:42:07 packer-plugin-tart plugin: 2022/09/15 09:42:07 Serving a plugin connection...
2022/09/15 09:42:07 packer-plugin-tart plugin: 2022/09/15 09:42:07 [TRACE] starting builder cli
2022/09/15 09:42:07 ConfigSpec failed: gob: type cty.Type has no exported fields
2022/09/15 09:42:07 waiting for all plugin processes to complete...
2022/09/15 09:42:07 /Users/edi/.packer.d/plugins/packer-plugin-tart: plugin process exited
panic: ConfigSpec failed: gob: type cty.Type has no exported fields [recovered]
	panic: ConfigSpec failed: gob: type cty.Type has no exported fields

[...]
```