### PR TITLE
Bump Golang to 1.19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.19
       - name: Describe plugin
         id: plugin_describe
         run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"


### PR DESCRIPTION
[`Cmd.Environ()`](https://pkg.go.dev/os/exec@master#Cmd.Environ) was only [added in Golang 1.19](https://tip.golang.org/doc/go1.19).

@fkorotkov please re-create the `v0.5.0` tag too as the build had failed.