### PR TITLE
Introduce "create_grace_time" option

### DIFF
--- a/builder/tart/builder.go
+++ b/builder/tart/builder.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
+	"time"
 )
 
 const BuilderId = "tart.builder"
@@ -30,6 +31,7 @@ type Config struct {
 	Display               string              `mapstructure:"display" required:"false"`
 	DiskSizeGb            uint16              `mapstructure:"disk_size_gb" required:"false"`
 	Headless              bool                `mapstructure:"headless" required:"false"`
+	CreateGraceTime       time.Duration       `mapstructure:"create_grace_time" required:"false"`
 	Comm                  communicator.Config `mapstructure:",squash"`
 
 	ctx interpolate.Context

--- a/builder/tart/builder.hcl2spec.go
+++ b/builder/tart/builder.hcl2spec.go
@@ -32,6 +32,7 @@ type FlatConfig struct {
 	Display                   *string           `mapstructure:"display" required:"false" cty:"display" hcl:"display"`
 	DiskSizeGb                *uint16           `mapstructure:"disk_size_gb" required:"false" cty:"disk_size_gb" hcl:"disk_size_gb"`
 	Headless                  *bool             `mapstructure:"headless" required:"false" cty:"headless" hcl:"headless"`
+	CreateGraceTime           *string           `mapstructure:"create_grace_time" required:"false" cty:"create_grace_time" hcl:"create_grace_time"`
 	Type                      *string           `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
 	PauseBeforeConnect        *string           `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
 	SSHHost                   *string           `mapstructure:"ssh_host" cty:"ssh_host" hcl:"ssh_host"`
@@ -117,6 +118,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"display":                      &hcldec.AttrSpec{Name: "display", Type: cty.String, Required: false},
 		"disk_size_gb":                 &hcldec.AttrSpec{Name: "disk_size_gb", Type: cty.Number, Required: false},
 		"headless":                     &hcldec.AttrSpec{Name: "headless", Type: cty.Bool, Required: false},
+		"create_grace_time":            &hcldec.AttrSpec{Name: "create_grace_time", Type: cty.String, Required: false},
 		"communicator":                 &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":      &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},
 		"ssh_host":                     &hcldec.AttrSpec{Name: "ssh_host", Type: cty.String, Required: false},

--- a/builder/tart/step_create_vm.go
+++ b/builder/tart/step_create_vm.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"strconv"
+	"time"
 )
 
 type stepCreateVM struct{}
@@ -32,6 +33,11 @@ func (s *stepCreateVM) Run(ctx context.Context, state multistep.StateBag) multis
 		ui.Error(err.Error())
 
 		return multistep.ActionHalt
+	}
+
+	if config.CreateGraceTime != 0 {
+		ui.Say("Waiting some time to let the Virtualization.Framework's installation process to finish correctly...")
+		time.Sleep(config.CreateGraceTime)
 	}
 
 	return multistep.ActionContinue


### PR DESCRIPTION
**Problem:** when invoking "tart run" straight after "tart create", the former may display a black screen. The culprit seems to be the `Virtualization.Framework`, which still doesn't close the VM's files for some time after the Tart terminates:

```
% tart create --from-ipsw=latest vm ; lsof ~/.tart/vms/vm/disk.img ~/.tart/vms/vm/nvram.bin
Using cached *.ipsw file...
Installing OS...
100%
COMMAND    PID USER   FD   TYPE DEVICE    SIZE/OFF     NODE NAME
com.apple 9830  edi    3u   REG   1,16    33570816 11748431 /Users/edi/.tart/vms/vm/nvram.bin
com.apple 9830  edi    4u   REG   1,16 50000000000 11748432 /Users/edi/.tart/vms/vm/disk.img
```

**Solution:** introduce an option that if specified, will force the Packer plugin to wait for the specified time after "tart create" finishes.