### PR TITLE
Bump to go 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module packer-plugin-tart
 
-go 1.17
+go 1.19
 
 require (
 	github.com/diskfs/go-diskfs v1.2.0


### PR DESCRIPTION
The [Environ() function](https://pkg.go.dev/os/exec@go1.19.2#Cmd.Environ) was implemented in go 1.19, this bumps the module required version to match.

https://github.com/cirruslabs/packer-plugin-tart/blame/d0187878700616ab5178124ecf74b8c77951e826/builder/tart/step_run.go#L49