### PR TITLE
Add support for linux VMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ main
 dist/*
 packer-plugin-tart
 .docs/*
+
+example/*.iso
+example/cidata/*

--- a/builder/tart/builder.go
+++ b/builder/tart/builder.go
@@ -23,6 +23,7 @@ type Config struct {
 	common.PackerConfig   `mapstructure:",squash"`
 	bootcommand.VNCConfig `mapstructure:",squash"`
 	FromIPSW              string              `mapstructure:"from_ipsw" required:"true"`
+	FromISO               []string            `mapstructure:"from_iso" required:"true"`
 	VMName                string              `mapstructure:"vm_name" required:"true"`
 	VMBaseName            string              `mapstructure:"vm_base_name" required:"true"`
 	Recovery              bool                `mapstructure:"recovery" required:"false"`
@@ -62,6 +63,8 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 
 	if b.config.FromIPSW != "" {
 		steps = append(steps, new(stepCreateVM))
+	} else if len(b.config.FromISO) > 0 {
+		steps = append(steps, new(stepCreateLinuxVM))
 	} else if b.config.VMBaseName != "" {
 		steps = append(steps, new(stepCloneVM))
 	}

--- a/builder/tart/builder.hcl2spec.go
+++ b/builder/tart/builder.hcl2spec.go
@@ -24,6 +24,7 @@ type FlatConfig struct {
 	DisableVNC                *bool             `mapstructure:"disable_vnc" cty:"disable_vnc" hcl:"disable_vnc"`
 	BootKeyInterval           *string           `mapstructure:"boot_key_interval" cty:"boot_key_interval" hcl:"boot_key_interval"`
 	FromIPSW                  *string           `mapstructure:"from_ipsw" required:"true" cty:"from_ipsw" hcl:"from_ipsw"`
+	FromISO                   []string          `mapstructure:"from_iso" required:"true" cty:"from_iso" hcl:"from_iso"`
 	VMName                    *string           `mapstructure:"vm_name" required:"true" cty:"vm_name" hcl:"vm_name"`
 	VMBaseName                *string           `mapstructure:"vm_base_name" required:"true" cty:"vm_base_name" hcl:"vm_base_name"`
 	Recovery                  *bool             `mapstructure:"recovery" required:"false" cty:"recovery" hcl:"recovery"`
@@ -110,6 +111,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disable_vnc":                  &hcldec.AttrSpec{Name: "disable_vnc", Type: cty.Bool, Required: false},
 		"boot_key_interval":            &hcldec.AttrSpec{Name: "boot_key_interval", Type: cty.String, Required: false},
 		"from_ipsw":                    &hcldec.AttrSpec{Name: "from_ipsw", Type: cty.String, Required: false},
+		"from_iso":                     &hcldec.AttrSpec{Name: "from_iso", Type: cty.List(cty.String), Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_base_name":                 &hcldec.AttrSpec{Name: "vm_base_name", Type: cty.String, Required: false},
 		"recovery":                     &hcldec.AttrSpec{Name: "recovery", Type: cty.Bool, Required: false},

--- a/builder/tart/step_create_linux_vm.go
+++ b/builder/tart/step_create_linux_vm.go
@@ -1,0 +1,106 @@
+package tart
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"os/exec"
+	"strconv"
+	"time"
+)
+
+type stepCreateLinuxVM struct{}
+
+func (s *stepCreateLinuxVM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	config := state.Get("config").(*Config)
+	ui := state.Get("ui").(packersdk.Ui)
+
+	ui.Say("Creating virtual machine...")
+
+	createArguments := []string{
+		"create",  "--linux",
+	}
+
+	if config.DiskSizeGb > 0 {
+		createArguments = append(createArguments, "--disk-size", strconv.Itoa(int(config.DiskSizeGb)))
+	}
+
+	createArguments = append(createArguments, config.VMName)
+
+	if _, err := TartExec(createArguments...); err != nil {
+		err := fmt.Errorf("Failed to create a VM: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+
+		return multistep.ActionHalt
+	}
+
+	if s.RunInstaller(ctx, state) != multistep.ActionContinue {
+		return multistep.ActionHalt
+	}
+
+	if config.CreateGraceTime != 0 {
+		message := fmt.Sprintf("Waiting %v to let the Virtualization.Framework's installation process "+
+			"to finish correctly...", config.CreateGraceTime)
+		ui.Say(message)
+		time.Sleep(config.CreateGraceTime)
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepCreateLinuxVM) Cleanup(state multistep.StateBag) {
+	// nothing to clean up
+}
+
+func (s *stepCreateLinuxVM) RunInstaller(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	config := state.Get("config").(*Config)
+	ui := state.Get("ui").(packersdk.Ui)
+
+	ui.Say("Starting the virtual machine for installation...")
+	runArgs := []string{"run", config.VMName, }
+	if config.Headless {
+		runArgs = append(runArgs, "--no-graphics")
+	} else {
+		runArgs = append(runArgs, "--graphics")
+	}
+	if !config.DisableVNC {
+		runArgs = append(runArgs, "--vnc-experimental")
+	}
+	for _, iso := range config.FromISO {
+		runArgs = append(runArgs, fmt.Sprintf("--disk=%s:ro", iso))
+	}
+	cmd := exec.Command("tart", runArgs...)
+	stdout := bytes.NewBufferString("")
+	cmd.Stdout = stdout
+	cmd.Stderr = uiWriter{ui: ui}
+
+	// Prevent the Tart from opening the Screen Sharing
+	// window connected to the VNC server we're starting
+	if !config.DisableVNC {
+		cmd.Env = cmd.Environ()
+		cmd.Env = append(cmd.Env, "CI=true")
+	}
+
+	if err := cmd.Start(); err != nil {
+		err = fmt.Errorf("Error starting VM: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	defer func() {
+		ui.Say("Waiting for the install process to shutdown the VM...")
+		_, _ = cmd.Process.Wait()
+	}()
+
+	if !config.DisableVNC {
+		if !typeBootCommandOverVNC(ctx, state, config, ui, stdout) {
+			return multistep.ActionHalt
+		}
+	}
+
+	return multistep.ActionContinue
+}

--- a/builder/tart/step_run.go
+++ b/builder/tart/step_run.go
@@ -59,7 +59,7 @@ func (s *stepRun) Run(ctx context.Context, state multistep.StateBag) multistep.S
 
 	state.Put("tart-cmd", cmd)
 
-	if !config.DisableVNC {
+	if (len(config.FromISO) == 0) && !config.DisableVNC {
 		if !typeBootCommandOverVNC(ctx, state, config, ui, stdout) {
 			return multistep.ActionHalt
 		}

--- a/example/ubuntu-22.04-hello.pkr.hcl
+++ b/example/ubuntu-22.04-hello.pkr.hcl
@@ -1,0 +1,39 @@
+packer {
+  required_plugins {
+    tart = {
+      version = ">= 0.5.3"
+      source  = "github.com/cirruslabs/tart"
+    }
+  }
+}
+
+source "tart-cli" "tart" {
+  vm_base_name        = "ubuntu-22.04-vanilla"
+  vm_name             = "ubuntu-22.04-hello"
+  cpu_count           = 4
+  memory_gb           = 8
+  disk_size_gb        = 10
+  headless            = true
+  disable_vnc         = true
+  ssh_password        = "ubuntu"
+  ssh_username        = "ubuntu"
+  ssh_timeout         = "120s"
+}
+
+build {
+  sources = ["source.tart-cli.tart"]
+
+  # resize the disk
+  provisioner "shell" {
+    inline = [
+      "sudo growpart /dev/vda 2",
+      "sudo resize2fs /dev/vda2"
+    ]
+  }
+
+  provisioner "shell" {
+    inline = [
+      "hello"
+    ]
+  }
+}

--- a/example/ubuntu-22.04-prepare.sh
+++ b/example/ubuntu-22.04-prepare.sh
@@ -1,0 +1,41 @@
+#!/bin/zsh
+
+set -eu
+
+if [ ! -f ubuntu-22.04.1-live-server-arm64.iso ]; then
+	echo "Downloading image..."
+	curl -fSLO https://cdimage.ubuntu.com/releases/22.04/release/ubuntu-22.04.1-live-server-arm64.iso
+fi
+
+if [ -d cidata ]; then
+	rm -rf cidata*
+fi
+
+mkdir cidata
+touch cidata/meta-data
+cat << 'EOF' > cidata/user-data
+#cloud-config
+autoinstall:
+  version: 1
+  identity:
+    hostname: ubuntu-server
+    # the password is ubuntu, needs to be encoded to /etc/shadow format
+    password: "$6$exDY1mhS4KUYCE/2$zmn9ToZwTKLhCw.b4/b.ZRTIZM30JZ4QrOQ2aOXJ8yk96xpcCof0kxKwuX1kqLG/ygbJ1f8wxED22bTL4F46P0"
+    username: ubuntu
+
+  storage:
+    swap:
+      size: 0
+    layout:
+      name: direct
+
+  ssh:
+    install-server: true
+    allow-pw: true
+
+  late-commands:
+    - "echo 'ubuntu ALL=(ALL) NOPASSWD: ALL' > /target/etc/sudoers.d/ubuntu-nopasswd"
+
+  shutdown: "poweroff"
+EOF
+hdiutil makehybrid -o cidata.iso cidata -joliet -iso

--- a/example/ubuntu-22.04-vanilla.pkr.hcl
+++ b/example/ubuntu-22.04-vanilla.pkr.hcl
@@ -1,0 +1,38 @@
+packer {
+  required_plugins {
+    tart = {
+      version = ">= 0.5.3"
+      source  = "github.com/cirruslabs/tart"
+    }
+  }
+}
+
+source "tart-cli" "tart" {
+  from_iso     = ["cidata.iso", "ubuntu-22.04.1-live-server-arm64.iso"]
+  vm_name      = "ubuntu-22.04-vanilla"
+  cpu_count    = 4
+  memory_gb    = 8
+  disk_size_gb = 8
+  boot_command = [
+    # grub
+    "<wait5s><enter>",
+    # autoinstall prompt
+    "<wait30s>yes<enter>"
+  ]
+  ssh_password = "ubuntu"
+  ssh_username = "ubuntu"
+  ssh_timeout  = "120s"
+}
+
+build {
+  sources = ["source.tart-cli.tart"]
+
+  provisioner "shell" {
+    environment_vars = ["DEBIAN_FRONTEND=noninteractive"]
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    inline = [
+      "apt-get update",
+      "apt-get install -y hello"
+    ]
+  }
+}


### PR DESCRIPTION
Resolves #32

I'm new to packer, go & provisioning in general so things might be ill formed but the example works.

Used https://ubuntu.com/server/docs/install/autoinstall-quickstart as a starting point for auto install.

A few notes:
It assumes the install process will shutdown the VM rather than restart it at the end of installation: the sample ubuntu autoinstall will just loop into the installer if the system is restarted rather than shutdown.
The auto-resize in the guest OS is probably less generic than the macOS one so ~~a `resize_disk_command` was introduced.~~ fixing the disk size is left to the user with generic shell provisioning steps.
The `boot_command` is hijacked to be used for the VM creation/installation rather than the following run.
