### PR TITLE
Added Rosseta support for existing Linux VMs

### DIFF
--- a/builder/tart/step_run.go
+++ b/builder/tart/step_run.go
@@ -38,6 +38,9 @@ func (s *stepRun) Run(ctx context.Context, state multistep.StateBag) multistep.S
 	if config.Recovery {
 		runArgs = append(runArgs, "--recovery")
 	}
+	if config.Rosetta != "" {
+		runArgs = append(runArgs, fmt.Sprintf("--rosetta=%s", config.Rosetta))
+	}
 	cmd := exec.Command("tart", runArgs...)
 	stdout := bytes.NewBufferString("")
 	cmd.Stdout = stdout

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "0.6.2"
+	Version = "0.6.3"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
Version 0.6.2 added Rosetta Support on VMs creation. This PR enables Packer to attach rosetta on existing VMs