### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installin
 ### Configuration
 
 For more information on how to configure the plugin, please read the
-documentation located in the [`docs/`](docs) directory.
-
+documentation located on the [HashiCorp's website](https://developer.hashicorp.com/packer/plugins/builders/tart).
 
 ## Contributing
 

--- a/builder/tart/builder.hcl2spec.go
+++ b/builder/tart/builder.hcl2spec.go
@@ -29,19 +29,6 @@ type FlatConfig struct {
 	HTTPPortMax               *int              `mapstructure:"http_port_max" cty:"http_port_max" hcl:"http_port_max"`
 	HTTPAddress               *string           `mapstructure:"http_bind_address" cty:"http_bind_address" hcl:"http_bind_address"`
 	HTTPInterface             *string           `mapstructure:"http_interface" undocumented:"true" cty:"http_interface" hcl:"http_interface"`
-	FromIPSW                  *string           `mapstructure:"from_ipsw" required:"true" cty:"from_ipsw" hcl:"from_ipsw"`
-	FromISO                   []string          `mapstructure:"from_iso" required:"true" cty:"from_iso" hcl:"from_iso"`
-	VMName                    *string           `mapstructure:"vm_name" required:"true" cty:"vm_name" hcl:"vm_name"`
-	VMBaseName                *string           `mapstructure:"vm_base_name" required:"true" cty:"vm_base_name" hcl:"vm_base_name"`
-	Recovery                  *bool             `mapstructure:"recovery" required:"false" cty:"recovery" hcl:"recovery"`
-	Rosetta                   *string           `mapstructure:"rosetta" required:"false" cty:"rosetta" hcl:"rosetta"`
-	CpuCount                  *uint8            `mapstructure:"cpu_count" required:"false" cty:"cpu_count" hcl:"cpu_count"`
-	MemoryGb                  *uint16           `mapstructure:"memory_gb" required:"false" cty:"memory_gb" hcl:"memory_gb"`
-	Display                   *string           `mapstructure:"display" required:"false" cty:"display" hcl:"display"`
-	DiskSizeGb                *uint16           `mapstructure:"disk_size_gb" required:"false" cty:"disk_size_gb" hcl:"disk_size_gb"`
-	Headless                  *bool             `mapstructure:"headless" required:"false" cty:"headless" hcl:"headless"`
-	RunExtraArgs              []string          `mapstructure:"run_extra_args" required:"false" cty:"run_extra_args" hcl:"run_extra_args"`
-	CreateGraceTime           *string           `mapstructure:"create_grace_time" required:"false" cty:"create_grace_time" hcl:"create_grace_time"`
 	Type                      *string           `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
 	PauseBeforeConnect        *string           `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
 	SSHHost                   *string           `mapstructure:"ssh_host" cty:"ssh_host" hcl:"ssh_host"`
@@ -91,6 +78,19 @@ type FlatConfig struct {
 	WinRMUseSSL               *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
+	FromIPSW                  *string           `mapstructure:"from_ipsw" cty:"from_ipsw" hcl:"from_ipsw"`
+	FromISO                   []string          `mapstructure:"from_iso" cty:"from_iso" hcl:"from_iso"`
+	VMBaseName                *string           `mapstructure:"vm_base_name" cty:"vm_base_name" hcl:"vm_base_name"`
+	VMName                    *string           `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
+	CpuCount                  *uint8            `mapstructure:"cpu_count" cty:"cpu_count" hcl:"cpu_count"`
+	CreateGraceTime           *string           `mapstructure:"create_grace_time" cty:"create_grace_time" hcl:"create_grace_time"`
+	DiskSizeGb                *uint16           `mapstructure:"disk_size_gb" cty:"disk_size_gb" hcl:"disk_size_gb"`
+	Display                   *string           `mapstructure:"display" cty:"display" hcl:"display"`
+	Headless                  *bool             `mapstructure:"headless" cty:"headless" hcl:"headless"`
+	MemoryGb                  *uint16           `mapstructure:"memory_gb" cty:"memory_gb" hcl:"memory_gb"`
+	Recovery                  *bool             `mapstructure:"recovery" cty:"recovery" hcl:"recovery"`
+	Rosetta                   *string           `mapstructure:"rosetta" cty:"rosetta" hcl:"rosetta"`
+	RunExtraArgs              []string          `mapstructure:"run_extra_args" cty:"run_extra_args" hcl:"run_extra_args"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -124,19 +124,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"http_port_max":                &hcldec.AttrSpec{Name: "http_port_max", Type: cty.Number, Required: false},
 		"http_bind_address":            &hcldec.AttrSpec{Name: "http_bind_address", Type: cty.String, Required: false},
 		"http_interface":               &hcldec.AttrSpec{Name: "http_interface", Type: cty.String, Required: false},
-		"from_ipsw":                    &hcldec.AttrSpec{Name: "from_ipsw", Type: cty.String, Required: false},
-		"from_iso":                     &hcldec.AttrSpec{Name: "from_iso", Type: cty.List(cty.String), Required: false},
-		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
-		"vm_base_name":                 &hcldec.AttrSpec{Name: "vm_base_name", Type: cty.String, Required: false},
-		"recovery":                     &hcldec.AttrSpec{Name: "recovery", Type: cty.Bool, Required: false},
-		"rosetta":                      &hcldec.AttrSpec{Name: "rosetta", Type: cty.String, Required: false},
-		"cpu_count":                    &hcldec.AttrSpec{Name: "cpu_count", Type: cty.Number, Required: false},
-		"memory_gb":                    &hcldec.AttrSpec{Name: "memory_gb", Type: cty.Number, Required: false},
-		"display":                      &hcldec.AttrSpec{Name: "display", Type: cty.String, Required: false},
-		"disk_size_gb":                 &hcldec.AttrSpec{Name: "disk_size_gb", Type: cty.Number, Required: false},
-		"headless":                     &hcldec.AttrSpec{Name: "headless", Type: cty.Bool, Required: false},
-		"run_extra_args":               &hcldec.AttrSpec{Name: "run_extra_args", Type: cty.List(cty.String), Required: false},
-		"create_grace_time":            &hcldec.AttrSpec{Name: "create_grace_time", Type: cty.String, Required: false},
 		"communicator":                 &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":      &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},
 		"ssh_host":                     &hcldec.AttrSpec{Name: "ssh_host", Type: cty.String, Required: false},
@@ -186,6 +173,19 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ssl":                &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
 		"winrm_insecure":               &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
+		"from_ipsw":                    &hcldec.AttrSpec{Name: "from_ipsw", Type: cty.String, Required: false},
+		"from_iso":                     &hcldec.AttrSpec{Name: "from_iso", Type: cty.List(cty.String), Required: false},
+		"vm_base_name":                 &hcldec.AttrSpec{Name: "vm_base_name", Type: cty.String, Required: false},
+		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
+		"cpu_count":                    &hcldec.AttrSpec{Name: "cpu_count", Type: cty.Number, Required: false},
+		"create_grace_time":            &hcldec.AttrSpec{Name: "create_grace_time", Type: cty.String, Required: false},
+		"disk_size_gb":                 &hcldec.AttrSpec{Name: "disk_size_gb", Type: cty.Number, Required: false},
+		"display":                      &hcldec.AttrSpec{Name: "display", Type: cty.String, Required: false},
+		"headless":                     &hcldec.AttrSpec{Name: "headless", Type: cty.Bool, Required: false},
+		"memory_gb":                    &hcldec.AttrSpec{Name: "memory_gb", Type: cty.Number, Required: false},
+		"recovery":                     &hcldec.AttrSpec{Name: "recovery", Type: cty.Bool, Required: false},
+		"rosetta":                      &hcldec.AttrSpec{Name: "rosetta", Type: cty.String, Required: false},
+		"run_extra_args":               &hcldec.AttrSpec{Name: "run_extra_args", Type: cty.List(cty.String), Required: false},
 	}
 	return s
 }

--- a/builder/tart/step_run.go
+++ b/builder/tart/step_run.go
@@ -103,7 +103,7 @@ func (s *stepRun) Cleanup(state multistep.StateBag) {
 		ui.Say("Gracefully shutting down the VM...")
 
 		shutdownCmd := packersdk.RemoteCmd{
-			Command: fmt.Sprintf("echo %s | sudo -S shutdown -h now", config.Comm.Password()),
+			Command: fmt.Sprintf("echo %s | sudo -S shutdown -h now", config.CommunicatorConfig.Password()),
 		}
 
 		err := shutdownCmd.RunWithUi(context.Background(), communicator.(packersdk.Communicator), ui)

--- a/docs/builders/tart.mdx
+++ b/docs/builders/tart.mdx
@@ -1,15 +1,16 @@
 ---
 description: >
-  The tart builder is used to create macOS and Linux virtual machines on Apple Silicon hardware.
+  The Tart builder is used to create macOS and Linux virtual machines on Apple Silicon hardware.
 page_title: Tart - Builders
 nav_title: Tart
 ---
 
-# What is Tart
+# Tart Builder
 
 Type: `tart`
 
 The `tart` builder is used to create macOS and Linux VMs for Apple Silicon powered by [Tart virtualization](https://github.com/cirruslabs/tart).
+
 Here are some highlights of Tart:
 
 * Tart uses Apple's own `Virtualization.Framework` for [near-native performance](https://browser.geekbench.com/v5/cpu/compare/14966395?baseline=14966339).
@@ -27,27 +28,47 @@ tart clone ghcr.io/cirruslabs/macos-ventura-vanilla:latest ventura-vanilla
 tart run ventura-vanilla
 ```
 
-Below we'll go through available options of this Packer plugin
+Below we'll go through available options of this Packer plugin.
 
 <!-- Builder Configuration Fields -->
 
 ### Required Configuration
 
-- `vm_name` (string) - The name of the VM to be created.
+- `vm_name` (string) - The name of the VM to create (only when `from_ipsw`, `from_iso` or `vm_base_name` are used) and run.
 
 ### Optional Configuration
 
-- `vm_base_name` (string) - The name of the VM to be used for the initial cloning. Can be either a local VM or a remote VM that will be pulled from a registry.
-- `from_ipsw` (string) - Location of an IPSW file to initialize a macOS virtual machine from. Can be either an absolute path to a file on disk on file or an URL to a remote file.
-- `from_iso` (string) - Location of an ISO file to initialize a Linux virtual machine from. An absolute path to a file on disk.
-- `cpu_count` (int) - Amount of virtual CPUs for the new VM to use by default. Default value is inherited from the base VM.
-- `memory_gb` (int) - Amount of unified memory in GB for the new VM to use by default. Default value is inherited from the base VM.
+- `cpu_count` (number) - Amount of virtual CPUs to use for the new VM. Overrides `tart create` default value when using `from_ipsw` and `from_iso` and VM settings when using `vm_base_name`.
+- `create_grace_time` (duration string | ex: "1h5m2s") — Time to wait after finishing the installation process. Can be used to work around the issue when Virtualization.Framework's installation process is still running in the background for some time after `tart create` had already finished.
+- `disk_size_gb` — Disk size in GB to use for the new VM. Overrides `tart create` default value when using `from_ipsw` and `from_iso` and VM settings when using `vm_base_name`.
+- `display` (string) — VM display resolution in a format of `<width>x<height>` (e.g. `1200x800`) to use for the new VM. Overrides `tart create` default value when using `from_ipsw` and `from_iso` and VM settings when using `vm_base_name`.
+- `from_ipsw` (string) - Location of an IPSW file to initialize a macOS virtual machine from. Can be either an absolute path to a file on disk, URL to fetch a remote file or `latest`. Mutually exclusive with `from_iso` and `vm_base_name`.
+- `from_iso` (list(string)) - Location of the ISO files to initialize a Linux virtual machine from. All values should represent an absolute path to a file on disk. Mutually exclusive with `from_ipsw` and `vm_base_name`.
+- `headless` (bool) - Whether to show graphics interface of a VM. Useful for debugging the `boot_command`.
+- `memory_gb` (number) - Amount of unified memory in GB to use for the new VM. Overrides `tart create` default value when using `from_ipsw` and `from_iso` and VM settings when using `vm_base_name`.
+- `recovery` (bool) — Whether to boot the VM in recovery mode. Useful for disabling the System Integrity Protection automatically for the already created VMs.
+- `rosetta` (string) - Whether to enable Rosetta support of a Linux guest VM. Useful for running non-arm64 binaries in the guest VM. A common used value is `rosetta`, for further details and explanation run `tart run --help`.
+- `run_extra_args` (list(string)) - Extra arguments to pass to `tart run` command. For example, you can enable bridged networking by specifying `--net-bridged=en0`.
+- `vm_base_name` (string) - The name of the VM to be used for the initial cloning. Can be either a local VM or a remote VM that will be pulled from a registry. Mutually exclusive with `from_ipsw` and `from_iso`.
+
+### SSH connection configuration
+
 - `ssh_username` (string) - Username to use for the communication over SSH to run provision steps.
 - `ssh_password` (string) - Password to use for the communication over SSH to run provision steps.
-- `headless` (boolean) - Whether to show graphics interface of a VM. Useful for debugging `boot_command`.
-- `rosetta` (string) - Whether to enable Rosetta support of a Linux guest VM. Useful for running non arm64 programs in the guest VM. A common used value is `rosetta`. For further details and explanation run `tart run --help`
-- `boot_command` (array of strings) - This is an array of commands to type when the virtual machine is first booted. The goal of these commands should be to type just enough to initialize the operating system installer.
-- `run_extra_args` (array of strings) - Extra arguments to pass to `tart run` command. For example, pass a bridged network via `--net-bridged=en0`.
+
+## HTTP server configuration
+
+@include 'packer-plugin-sdk/multistep/commonsteps/HTTPConfig.mdx'
+
+### Optional:
+
+@include 'packer-plugin-sdk/multistep/commonsteps/HTTPConfig-not-required.mdx'
+
+### VNC configuration
+
+### Optional:
+
+- `boot_command` (list(string)) - Commands to type over VNC when the virtual machine is first booted. The goal of these commands should be to type just enough to initialize the operating system installer.
 
 ### Example Usage
 
@@ -81,6 +102,4 @@ build {
 }
 ```
 
-For more advanced examples please referer to [this repository](https://github.com/cirruslabs/macos-image-templates).
-
-
+For more advanced examples, please referer to [this repository](https://github.com/cirruslabs/macos-image-templates).


### PR DESCRIPTION
Not sure if `@include` are going to work, though, I've found this usage in https://github.com/Parallels/packer-plugin-parallels/blob/9d6e82ed5f964af828ea03344adeb1c4cb98799b/docs/builders/iso.mdx?plain=1#L220-L226.

Also sorted the configuration fields for easier matching with the documentation and removed the misleading `required:"true"` modifiers as they're non-effectual when using `mapstructure`, see https://pkg.go.dev/github.com/hashicorp/packer/cmd/mapstructure-to-hcl2:

>In mapstructure everything is optional.

Resolves https://github.com/cirruslabs/packer-plugin-tart/issues/75.