### PR TITLE
Add `allow_insecure` flag for pulling from insecure repositories

### DIFF
--- a/builder/tart/builder.go
+++ b/builder/tart/builder.go
@@ -5,6 +5,8 @@ package tart
 import (
 	"context"
 	"errors"
+	"time"
+
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer-plugin-sdk/bootcommand"
 	"github.com/hashicorp/packer-plugin-sdk/common"
@@ -14,7 +16,6 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
-	"time"
 )
 
 const BuilderId = "tart.builder"

--- a/builder/tart/builder.go
+++ b/builder/tart/builder.go
@@ -26,10 +26,11 @@ type Config struct {
 	commonsteps.HTTPConfig `mapstructure:",squash"`
 	CommunicatorConfig     communicator.Config `mapstructure:",squash"`
 
-	FromIPSW   string   `mapstructure:"from_ipsw"`
-	FromISO    []string `mapstructure:"from_iso"`
-	VMBaseName string   `mapstructure:"vm_base_name"`
-	VMName     string   `mapstructure:"vm_name"`
+	FromIPSW      string   `mapstructure:"from_ipsw"`
+	FromISO       []string `mapstructure:"from_iso"`
+	VMBaseName    string   `mapstructure:"vm_base_name"`
+	VMName        string   `mapstructure:"vm_name"`
+	AllowInsecure bool     `mapstructure:"allow_insecure"`
 
 	CpuCount        uint8         `mapstructure:"cpu_count"`
 	CreateGraceTime time.Duration `mapstructure:"create_grace_time"`

--- a/builder/tart/builder.hcl2spec.go
+++ b/builder/tart/builder.hcl2spec.go
@@ -82,6 +82,7 @@ type FlatConfig struct {
 	FromISO                   []string          `mapstructure:"from_iso" cty:"from_iso" hcl:"from_iso"`
 	VMBaseName                *string           `mapstructure:"vm_base_name" cty:"vm_base_name" hcl:"vm_base_name"`
 	VMName                    *string           `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
+	AllowInsecure             *bool             `mapstructure:"allow_insecure" cty:"allow_insecure" hcl:"allow_insecure"`
 	CpuCount                  *uint8            `mapstructure:"cpu_count" cty:"cpu_count" hcl:"cpu_count"`
 	CreateGraceTime           *string           `mapstructure:"create_grace_time" cty:"create_grace_time" hcl:"create_grace_time"`
 	DiskSizeGb                *uint16           `mapstructure:"disk_size_gb" cty:"disk_size_gb" hcl:"disk_size_gb"`
@@ -177,6 +178,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"from_iso":                     &hcldec.AttrSpec{Name: "from_iso", Type: cty.List(cty.String), Required: false},
 		"vm_base_name":                 &hcldec.AttrSpec{Name: "vm_base_name", Type: cty.String, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
+		"allow_insecure":               &hcldec.AttrSpec{Name: "allow_insecure", Type: cty.Bool, Required: false},
 		"cpu_count":                    &hcldec.AttrSpec{Name: "cpu_count", Type: cty.Number, Required: false},
 		"create_grace_time":            &hcldec.AttrSpec{Name: "create_grace_time", Type: cty.String, Required: false},
 		"disk_size_gb":                 &hcldec.AttrSpec{Name: "disk_size_gb", Type: cty.Number, Required: false},

--- a/builder/tart/step_clone_vm.go
+++ b/builder/tart/step_clone_vm.go
@@ -16,7 +16,13 @@ func (s *stepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 
 	ui.Say("Cloning virtual machine...")
 
-	if _, err := TartExec(ctx, "clone", config.VMBaseName, config.VMName); err != nil {
+	cmdArgs := []string{"clone", config.VMBaseName, config.VMName}
+
+	if config.AllowInsecure {
+		cmdArgs = append(cmdArgs, "--insecure")
+	}
+
+	if _, err := TartExec(ctx, cmdArgs...); err != nil {
 		err := fmt.Errorf("Error cloning VM: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/builder/tart/step_clone_vm.go
+++ b/builder/tart/step_clone_vm.go
@@ -3,6 +3,7 @@ package tart
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )

--- a/docs/builders/tart.mdx
+++ b/docs/builders/tart.mdx
@@ -13,10 +13,10 @@ The `tart` builder is used to create macOS and Linux VMs for Apple Silicon power
 
 Here are some highlights of Tart:
 
-* Tart uses Apple's own `Virtualization.Framework` for [near-native performance](https://browser.geekbench.com/v5/cpu/compare/14966395?baseline=14966339).
-* Push/Pull virtual machines from any OCI-compatible container registry.
-* Built-in CI integration.
-* Use this Tart Packer Plugin to automate VM creation.
+- Tart uses Apple's own `Virtualization.Framework` for [near-native performance](https://browser.geekbench.com/v5/cpu/compare/14966395?baseline=14966339).
+- Push/Pull virtual machines from any OCI-compatible container registry.
+- Built-in CI integration.
+- Use this Tart Packer Plugin to automate VM creation.
 
 ## How to get started with Tart
 

--- a/docs/builders/tart.mdx
+++ b/docs/builders/tart.mdx
@@ -38,7 +38,7 @@ Below we'll go through available options of this Packer plugin.
 
 ### Optional Configuration
 
-- `allow_insecure` (boolean) — Connect to the OCI registry via insecure HTTP protocol
+- `allow_insecure` (boolean) — When cloning the image, connect to the OCI registry via an insecure HTTP protocol.
 - `cpu_count` (number) - Amount of virtual CPUs to use for the new VM. Overrides `tart create` default value when using `from_ipsw` and `from_iso` and VM settings when using `vm_base_name`.
 - `create_grace_time` (duration string | ex: "1h5m2s") — Time to wait after finishing the installation process. Can be used to work around the issue when Virtualization.Framework's installation process is still running in the background for some time after `tart create` had already finished.
 - `disk_size_gb` — Disk size in GB to use for the new VM. Overrides `tart create` default value when using `from_ipsw` and `from_iso` and VM settings when using `vm_base_name`.

--- a/docs/builders/tart.mdx
+++ b/docs/builders/tart.mdx
@@ -38,6 +38,7 @@ Below we'll go through available options of this Packer plugin.
 
 ### Optional Configuration
 
+- `allow_insecure` (boolean) — Connect to the OCI registry via insecure HTTP protocol
 - `cpu_count` (number) - Amount of virtual CPUs to use for the new VM. Overrides `tart create` default value when using `from_ipsw` and `from_iso` and VM settings when using `vm_base_name`.
 - `create_grace_time` (duration string | ex: "1h5m2s") — Time to wait after finishing the installation process. Can be used to work around the issue when Virtualization.Framework's installation process is still running in the background for some time after `tart create` had already finished.
 - `disk_size_gb` — Disk size in GB to use for the new VM. Overrides `tart create` default value when using `from_ipsw` and `from_iso` and VM settings when using `vm_base_name`.


### PR DESCRIPTION
Adds the ability to do `allow_insecure = true` to add `--insecure` to `tart clone` command.