### PR TITLE
Respect boot_wait for VNC

### DIFF
--- a/builder/tart/builder.go
+++ b/builder/tart/builder.go
@@ -34,7 +34,6 @@ type Config struct {
 
 	CpuCount        uint8         `mapstructure:"cpu_count"`
 	CreateGraceTime time.Duration `mapstructure:"create_grace_time"`
-	BootWait        time.Duration `mapstructure:"boot_wait"`
 	DiskSizeGb      uint16        `mapstructure:"disk_size_gb"`
 	Display         string        `mapstructure:"display"`
 	Headless        bool          `mapstructure:"headless"`

--- a/builder/tart/builder.go
+++ b/builder/tart/builder.go
@@ -34,6 +34,7 @@ type Config struct {
 
 	CpuCount        uint8         `mapstructure:"cpu_count"`
 	CreateGraceTime time.Duration `mapstructure:"create_grace_time"`
+	BootWait        time.Duration `mapstructure:"boot_wait"`
 	DiskSizeGb      uint16        `mapstructure:"disk_size_gb"`
 	Display         string        `mapstructure:"display"`
 	Headless        bool          `mapstructure:"headless"`

--- a/builder/tart/step_run.go
+++ b/builder/tart/step_run.go
@@ -207,10 +207,10 @@ func typeBootCommandOverVNC(
 
 	ui.Say("Connected to the VNC!")
 
-	if config.BootWait > 0 {
-		message := fmt.Sprintf("Waiting %v after the VM has booted...", config.BootWait)
+	if config.VNCConfig.BootWait > 0 {
+		message := fmt.Sprintf("Waiting %v after the VM has booted...", config.VNCConfig.BootWait)
 		ui.Say(message)
-		time.Sleep(config.BootWait)
+		time.Sleep(config.VNCConfig.BootWait)
 	}
 
 	vncDriver := bootcommand.NewVNCDriver(vncClient, config.BootKeyInterval)

--- a/builder/tart/step_run.go
+++ b/builder/tart/step_run.go
@@ -207,6 +207,12 @@ func typeBootCommandOverVNC(
 
 	ui.Say("Connected to the VNC!")
 
+	if config.BootWait != 0 {
+		message := fmt.Sprintf("Waiting %v for VM to boot...", config.BootWait)
+		ui.Say(message)
+		time.Sleep(config.BootWait)
+	}
+
 	vncDriver := bootcommand.NewVNCDriver(vncClient, config.BootKeyInterval)
 
 	ui.Say("Typing the commands over VNC...")

--- a/builder/tart/step_run.go
+++ b/builder/tart/step_run.go
@@ -208,7 +208,7 @@ func typeBootCommandOverVNC(
 	ui.Say("Connected to the VNC!")
 
 	if config.BootWait != 0 {
-		message := fmt.Sprintf("Waiting %v for VM to boot...", config.BootWait)
+		message := fmt.Sprintf("Waiting %v after the VM has booted...", config.BootWait)
 		ui.Say(message)
 		time.Sleep(config.BootWait)
 	}

--- a/builder/tart/step_run.go
+++ b/builder/tart/step_run.go
@@ -207,7 +207,7 @@ func typeBootCommandOverVNC(
 
 	ui.Say("Connected to the VNC!")
 
-	if config.BootWait != 0 {
+	if config.BootWait > 0 {
 		message := fmt.Sprintf("Waiting %v after the VM has booted...", config.BootWait)
 		ui.Say(message)
 		time.Sleep(config.BootWait)


### PR DESCRIPTION
Currently the `boot_wait` command does not do anything, even though it is [documented](https://developer.hashicorp.com/packer/plugins/builders/tart#boot_wait) as "The time to wait after booting the initial virtual machine before typing the boot_command".

Currently the workaround I have been using is to add `<wait90s>` in the `boot_command`, which works but makes the config a little harder to follow.

It seems this was caused as the boot wait was not currently implemented fully, so this PR adds this functionality.

For example, setting `boot_wait = "90s"` will now produce:

```
==> tart-cli.vm: Starting the virtual machine...
==> tart-cli.vm: Waiting for the VNC server credentials from Tart...
==> tart-cli.vm: Retrieved VNC credentials, connecting...
==> tart-cli.vm: Connected to the VNC!
==> tart-cli.vm: Waiting 1m30s for VM to boot...
==> tart-cli.vm: Typing the commands over VNC...
```

This allows time for the VM to boot properly before VNC commands are issued, preventing unexpected behaviour.