### PR TITLE
Don't filter out boot_command in interpolate

### DIFF
--- a/builder/tart/builder.go
+++ b/builder/tart/builder.go
@@ -56,9 +56,6 @@ func (b *Builder) Prepare(raws ...interface{}) (generatedVars []string, warnings
 	err = config.Decode(&b.config, &config.DecodeOpts{
 		PluginType:  "packer.builder.tart",
 		Interpolate: true,
-		InterpolateFilter: &interpolate.RenderFilter{
-			Exclude: []string{"boot_command"},
-		},
 	}, raws...)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
The boot_command should also be interpolated. Otherwise, the following packer will fail with an error:

```
{
  "builders": [
    {
      "type": "tart-cli",
      "name": "vm-macos12-arm64:packer-base-tart",
      "vm_name": "vm-macos12-x64-packer-base-tart-currently-building{{user `tart_suffix`}}",
      "headless": false,

      "from_ipsw": "https://updates.cdn-apple.com/2022FallFCS/fullrestores/012-40537/0EC7C669-13E9-49FB-BD64-9EECC1D174B2/UniversalMac_12.6_21G115_Restore.ipsw",
      "cpu_count": 2,
      "memory_gb": 4,

      "boot_wait": "3m",
      "recovery": true,
      "boot_command": [
        "<wait60s><right><right><enter>",
        "<wait10s><enter>",
        "<wait10s><leftCtrlOn><f2><leftCtrlOff>",
        "<right><right><right><right><down><down><down><enter>",
        "<wait10s>",
        "diskutil eraseDisk JHFS+ 'Macintosh HD' disk0<enter>",
        "<wait5s>",
        "curl -o /tmp/bootstrap.pkg http://{{ .HTTPIP }}:{{ .HTTPPort }}/vm-bootstrap.pkg<enter>",
        "USER={{user `username`}} PASSWORD={{user `password`}} '/Volumes/Image Volume/Install macOS'*'.app/Contents/Resources/startosinstall' --agreetolicense --volume '/Volumes/Macintosh HD' --installpackage /tmp/bootstrap.pkg<enter>"
      ],
      "http_directory": "http_root/",
      "ssh_port": 22,
      "ssh_username": "{{user `username`}}",
      "ssh_password": "{{user `password`}}",
      "ssh_wait_timeout": "10000s"
    }
  ],
  "variables": {
    "output_directory": "{{env `PACKER_OUTPUT_DIR`}}",
    "username": "admin",
    "password": "admin",
    "tart_suffix": "-{{env `CI_PIPELINE_ID`}}"
  }
}
```

It will fail with these logs:

```
==> vm-macos12-arm64:packer-base-tart: Typing the commands over VNC...
==> vm-macos12-arm64:packer-base-tart: Failed to render the boot command: template: root:1:300: executing "root" at <user `username`>: error calling user: test
==> vm-macos12-arm64:packer-base-tart: Waiting for the tart process to exit...
```

Due to entering the following error path in the SDK: https://github.com/hashicorp/packer-plugin-sdk/blob/main/template/interpolate/funcs.go#L225C15-L225C21 (yes, you read that right. `errors.New("test")`).