### PR TITLE
Don't interpolate boot_command too early

### DIFF
--- a/builder/tart/builder.go
+++ b/builder/tart/builder.go
@@ -57,6 +57,12 @@ func (b *Builder) Prepare(raws ...interface{}) (generatedVars []string, warnings
 	err = config.Decode(&b.config, &config.DecodeOpts{
 		PluginType:  "packer.builder.tart",
 		Interpolate: true,
+		InterpolateFilter: &interpolate.RenderFilter{
+			// Postpone the boot_command interpolation because
+			// we don't know the HTTPIP and HTTPPort yet
+			Exclude: []string{"boot_command"},
+		},
+		InterpolateContext: &b.config.ctx,
 	}, raws...)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
...and initialize the interpolation context properly.

With this PR, both of the examples work:

```hcl
source "tart-cli" "tart" {
  vm_base_name   = "macos"
  vm_name        = "packer"
  http_directory = "/tmp/"
  boot_command   = [
    "<wait15s>{{ .HTTPIP }} {{ .HTTPPort }}<wait60s>",
  ]
  ssh_username   = "admin"
  ssh_password   = "admin"
}

build {
  sources = ["source.tart-cli.tart"]
}
```

```json
{
  "builders": [
    {
      "type": "tart-cli",
      "name": "user-variable-test",
      "vm_base_name": "ghcr.io/cirruslabs/macos-ventura-base:latest",
      "vm_name": "user-variable-test-vm",
      "headless": false,
      "boot_command": [
        "{{user `some_variable`}}"
      ],
      "ssh_username": "admin",
      "ssh_password": "admin"
    }
  ],
  "variables": {
    "some_variable": "some value"
  }
}
```

Resolves #99.