### PR TITLE
docs/README.md: Fix broken plugin links on integration portal

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -10,7 +10,7 @@ Here are some highlights of Tart:
 
 ### Installation
 
-To install this plugin, copy and paste this code into your Packer configuration, then run [`packer init`](https://www.packer.io/docs/commands/init).
+To install this plugin, copy and paste this code into your Packer configuration, then run [`packer init`](https://developer.hashicorp.com/packer/docs/commands/init).
 
 ```hcl
 packer {
@@ -33,7 +33,7 @@ $ packer plugins install github.com/cirruslabs/tart
 
 #### Builders
 
-- [tart](/packer/integrations/cirruslabs/latest/components/builder/tart) - The builder takes a template (in gridscale) or an iso-image, runs any provisioning necessary on the template/iso-image after launching it, then snapshots it into a reusable template. This reusable template can then be used as the foundation of new servers that are provisioned within gridscale user space.
+- [tart](/packer/integrations/cirruslabs/tart/latest/components/builder/tart) - The builder is used to create macOS and Linux VMs for Apple Silicon powered by [Tart virtualization](https://github.com/cirruslabs/tart).
 
 ### Getting Started
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Here are some highlights of Tart:
 
 ### Installation
 
-To install this plugin, copy and paste this code into your Packer configuration, then run [`packer init`](https://www.packer.io/docs/commands/init).
+To install this plugin, copy and paste this code into your Packer configuration, then run [`packer init`](https://developer.hashicorp.com/packer/docs/commands/init).
 
 ```hcl
 packer {
@@ -33,7 +33,7 @@ $ packer plugins install github.com/cirruslabs/tart
 
 #### Builders
 
-- [tart](/packer/integrations/cirruslabs/latest/components/builder/tart) - The builder takes a template (in gridscale) or an iso-image, runs any provisioning necessary on the template/iso-image after launching it, then snapshots it into a reusable template. This reusable template can then be used as the foundation of new servers that are provisioned within gridscale user space.
+- [tart](/packer/integrations/cirruslabs/tart/latest/components/builder/tart) - The builder is used to create macOS and Linux VMs for Apple Silicon powered by [Tart virtualization](https://github.com/cirruslabs/tart).
 
 ### Getting Started
 


### PR DESCRIPTION
This change updates the links to the plugin components on the main integration [index page](https://developer.hashicorp.com/packer/integrations/cirruslabs/tart), with the correct URL structure. Integration links now take the following URL format
 `/packer/integrations/org-name/plugin-name/latest/components/type/name`. 

After merging please trigger a manual notify integration release job with the latest plugin version to refresh the integration portal. Otherwise, the links will remain broken until the next official plugin release. 

#### Preview
<img width="936" alt="image" src="https://github.com/cirruslabs/packer-plugin-tart/assets/1749304/9eae3c76-c503-4b1d-aa0e-1b411d7f3397">
