### PR TITLE
Added http_ip to provide PACKER_HTTP_ADDRESS to the provisioner scripts

### DIFF
--- a/builder/tart/step_run.go
+++ b/builder/tart/step_run.go
@@ -141,6 +141,7 @@ func typeBootCommandOverVNC(
 		}
 
 		ui.Say(fmt.Sprintf("Host IP is assumed to be %s", hostIP))
+		state.Put("http_ip", hostIP)
 
 		// Should be already filled by the Packer's commonsteps.StepHTTPServer
 		httpPort := state.Get("http_port").(int)


### PR DESCRIPTION
Simple change to provide PACKER_HTTP_ADDRESS & PACKER_HTTP_IP to the provisioner scripts.

fixes: #117