### PR TITLE
Added notification for user about located VNC password & address

### DIFF
--- a/builder/tart/step_run.go
+++ b/builder/tart/step_run.go
@@ -181,7 +181,7 @@ func typeBootCommandOverVNC(
 	ui.Say("Retrieved VNC credentials, connecting...")
 	ui.Message(fmt.Sprintf(
 		"If you want to view the screen of the VM, connect via VNC with the password \"%s\" to\n"+
-			"vnc://%s:%d", vncPassword, vncHost, vncPort))
+			"vnc://%s:%s", vncPassword, vncHost, vncPort))
 
 	dialer := net.Dialer{}
 	netConn, err := dialer.DialContext(ctx, "tcp", fmt.Sprintf("%s:%s", vncHost, vncPort))

--- a/builder/tart/step_run.go
+++ b/builder/tart/step_run.go
@@ -179,6 +179,9 @@ func typeBootCommandOverVNC(
 	}
 
 	ui.Say("Retrieved VNC credentials, connecting...")
+	ui.Message(fmt.Sprintf(
+		"If you want to view the screen of the VM, connect via VNC with the password \"%s\" to\n"+
+			"vnc://%s:%d", vncPassword, vncHost, vncPort))
 
 	dialer := net.Dialer{}
 	netConn, err := dialer.DialContext(ctx, "tcp", fmt.Sprintf("%s:%s", vncHost, vncPort))


### PR DESCRIPTION
Following VMX driver practices - allowing user to see the VNC password for debugging purposes. It should not be a security concern, because such password is autogenerated during the image build.

Looks like that:
```
==> tart-cli: Waiting for the VNC server credentials from Tart...
==> tart-cli: Retrieved VNC credentials, connecting...
    tart-cli: If you want to view the screen of the VM, connect via VNC with the password "thumb-genre-width-motion" to
    tart-cli: vnc://127.0.0.1:60612
==> tart-cli: Connected to the VNC!
```

fixes: #114