### PR TITLE
Stream Tart stdout/stderr output to Packer UI

### DIFF
--- a/builder/tart/ssh.go
+++ b/builder/tart/ssh.go
@@ -9,5 +9,5 @@ func TartMachineIP(ctx context.Context, vmName string, ipExtraArgs []string) (st
 	if len(ipExtraArgs) > 0 {
 		ipArgs = append(ipArgs, ipExtraArgs...)
 	}
-	return TartExec(ctx, ipArgs...)
+	return TartExec(ctx, nil, ipArgs...)
 }

--- a/builder/tart/step_cleanup.go
+++ b/builder/tart/step_cleanup.go
@@ -21,6 +21,6 @@ func (s *stepCleanVM) Cleanup(state multistep.StateBag) {
 	if cancelled || halted {
 		ui.Say("Cleaning up virtual machine...")
 		cmdArgs := []string{"delete", config.VMName}
-		_, _ = TartExec(context.Background(), cmdArgs...)
+		_, _ = TartExec(context.Background(), ui, cmdArgs...)
 	}
 }

--- a/builder/tart/step_clone_vm.go
+++ b/builder/tart/step_clone_vm.go
@@ -26,11 +26,9 @@ func (s *stepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 		cmdArgs = append(cmdArgs, "--concurrency", fmt.Sprintf("%d", config.PullConcurrency))
 	}
 
-	if _, err := TartExec(ctx, cmdArgs...); err != nil {
+	if _, err := TartExec(ctx, ui, cmdArgs...); err != nil {
 		err := fmt.Errorf("Error cloning VM: %s", err)
 		state.Put("error", err)
-		ui.Error(err.Error())
-
 		return multistep.ActionHalt
 	}
 

--- a/builder/tart/step_create_linux_vm.go
+++ b/builder/tart/step_create_linux_vm.go
@@ -29,11 +29,9 @@ func (s *stepCreateLinuxVM) Run(ctx context.Context, state multistep.StateBag) m
 
 	createArguments = append(createArguments, config.VMName)
 
-	if _, err := TartExec(ctx, createArguments...); err != nil {
+	if _, err := TartExec(ctx, ui, createArguments...); err != nil {
 		err := fmt.Errorf("Failed to create a VM: %s", err)
 		state.Put("error", err)
-		ui.Error(err.Error())
-
 		return multistep.ActionHalt
 	}
 

--- a/builder/tart/step_create_vm.go
+++ b/builder/tart/step_create_vm.go
@@ -27,11 +27,9 @@ func (s *stepCreateVM) Run(ctx context.Context, state multistep.StateBag) multis
 
 	createArguments = append(createArguments, config.VMName)
 
-	if _, err := TartExec(ctx, createArguments...); err != nil {
+	if _, err := TartExec(ctx, ui, createArguments...); err != nil {
 		err := fmt.Errorf("Failed to create a VM: %s", err)
 		state.Put("error", err)
-		ui.Error(err.Error())
-
 		return multistep.ActionHalt
 	}
 

--- a/builder/tart/step_set_vm.go
+++ b/builder/tart/step_set_vm.go
@@ -32,10 +32,9 @@ func (s *stepSetVM) Run(ctx context.Context, state multistep.StateBag) multistep
 		setArguments = append(setArguments, "--display", config.Display)
 	}
 
-	if _, err := TartExec(ctx, setArguments...); err != nil {
+	if _, err := TartExec(ctx, ui, setArguments...); err != nil {
 		err := fmt.Errorf("Error updating VM: %s", err)
 		state.Put("error", err)
-		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
 


### PR DESCRIPTION
Creating a Tart VM may involve long running operations such as downloading an IPSW, or installing the OS. Tart gives us progress during these operations, so let's forward it to the Packer UI, the same way the shell-local provisioner does.

If a packer.Ui is not provided, we keep the previous code path that returns the output to the caller, for example used by the TartMachineIP helper.