### PR TITLE
Disable password prompt during cleanup shutdown

### DIFF
--- a/builder/tart/step_run.go
+++ b/builder/tart/step_run.go
@@ -103,7 +103,7 @@ func (s *stepRun) Cleanup(state multistep.StateBag) {
 		ui.Say("Gracefully shutting down the VM...")
 
 		shutdownCmd := packersdk.RemoteCmd{
-			Command: fmt.Sprintf("echo %s | sudo -S shutdown -h now", config.CommunicatorConfig.Password()),
+			Command: fmt.Sprintf("echo %s | sudo -S -p '' shutdown -h now", config.CommunicatorConfig.Password()),
 		}
 
 		err := shutdownCmd.RunWithUi(context.Background(), communicator.(packersdk.Communicator), ui)


### PR DESCRIPTION
We do `sudo -S shutdown -h now` to gracefully shut down during
cleanup, but the -S flag to sudo results in the prompt being
written to stderr, which results in scary looking red text
in the Packer log. Pass a custom empty prompt to silence it.