### PR TITLE
Skip unneeded steps

### DIFF
--- a/builder/tart/builder.go
+++ b/builder/tart/builder.go
@@ -104,10 +104,14 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	steps = append(steps,
 		new(stepSetVM),
 		new(stepDiskFilePrepare),
-		new(stepRun),
 	)
 
-	if !b.config.Recovery {
+	communicatorConfigured := b.config.CommunicatorConfig.Type != "none"
+	if len(b.config.BootCommand) > 0 || communicatorConfigured {
+		steps = append(steps, new(stepRun))
+	}
+
+	if !b.config.Recovery && communicatorConfigured {
 		steps = append(steps,
 			&communicator.StepConnect{
 				Config: &b.config.CommunicatorConfig,

--- a/builder/tart/step_run.go
+++ b/builder/tart/step_run.go
@@ -73,7 +73,7 @@ func (s *stepRun) Run(ctx context.Context, state multistep.StateBag) multistep.S
 
 	state.Put("tart-cmd", cmd)
 
-	if (len(config.FromISO) == 0) && !config.DisableVNC {
+	if len(config.BootCommand) > 0 && (len(config.FromISO) == 0) && !config.DisableVNC {
 		if !typeBootCommandOverVNC(ctx, state, config, ui, stdout) {
 			return multistep.ActionHalt
 		}


### PR DESCRIPTION
Without a communicator we can't provision, and if we don't have
boot commands there's not any keys to send to the running VM, so
running it is not needed.

This allows configuring builders that only create the VM,
in preparation for later OS installation and provisioning:

```hcl
source "tart-cli" "create-only" {
  cpu_count    = 4
  memory_gb    = 8
  disk_size_gb = 40
  from_ipsw    = var.ipsw_file
  vm_name      = "pre-install-vm"
  communicator = "none"
}
```

<img width="904" alt="image" src="https://github.com/cirruslabs/packer-plugin-tart/assets/7536/967e0ccc-9913-490c-bbd0-97866ca31258">


Also, there's no need to connect to VNC if we have no boot commands
to type.

<img width="849" alt="image" src="https://github.com/cirruslabs/packer-plugin-tart/assets/7536/879c7dc3-a191-4cd8-91ae-c5239eba58f0">
