### PR TITLE
Add environment variable to override Tart command

### DIFF
--- a/builder/tart/helpers.go
+++ b/builder/tart/helpers.go
@@ -14,7 +14,12 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/shell-local/localexec"
 )
 
-const tartCommand = "tart"
+func TartCommand() string {
+	if tart := os.Getenv("TART_COMMAND"); tart != "" {
+		return tart
+	}
+	return "tart"
+}
 
 func PathInTartHome(elem ...string) string {
 	if home := os.Getenv("TART_HOME"); home != "" {
@@ -28,7 +33,7 @@ func TartExec(ctx context.Context, ui packer.Ui, args ...string) (string, error)
 
 	log.Printf("Executing tart: %#v", args)
 
-	cmd := exec.CommandContext(ctx, tartCommand, args...)
+	cmd := exec.CommandContext(ctx, TartCommand(), args...)
 
 	if ui != nil {
 		return "", localexec.RunAndStream(cmd, ui, []string{})

--- a/builder/tart/step_create_linux_vm.go
+++ b/builder/tart/step_create_linux_vm.go
@@ -73,7 +73,7 @@ func runInstaller(ctx context.Context, state multistep.StateBag) multistep.StepA
 	for _, iso := range config.FromISO {
 		runArgs = append(runArgs, fmt.Sprintf("--disk=%s:ro", iso))
 	}
-	cmd := exec.CommandContext(ctx, tartCommand, runArgs...)
+	cmd := exec.CommandContext(ctx, TartCommand(), runArgs...)
 	stdout := bytes.NewBufferString("")
 	cmd.Stdout = stdout
 	cmd.Stderr = uiWriter{ui: ui}

--- a/builder/tart/step_run.go
+++ b/builder/tart/step_run.go
@@ -52,7 +52,7 @@ func (s *stepRun) Run(ctx context.Context, state multistep.StateBag) multistep.S
 	if len(config.RunExtraArgs) > 0 {
 		runArgs = append(runArgs, config.RunExtraArgs...)
 	}
-	cmd := exec.CommandContext(ctx, tartCommand, runArgs...)
+	cmd := exec.CommandContext(ctx, TartCommand(), runArgs...)
 	stdout := bytes.NewBufferString("")
 	cmd.Stdout = stdout
 	cmd.Stderr = uiWriter{ui: ui}


### PR DESCRIPTION
Via TART_COMMAND. Useful for pointing the Packer provisioning to a 'tart' that's not in path, for example if Tart is installed as a standalone application bundle, or for custom builds of Tart.