### PR TITLE
Use packer plugins install --path to install (development version)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,9 +10,9 @@ HASHICORP_PACKER_PLUGIN_SDK_VERSION?=$(shell go list -m github.com/hashicorp/pac
 build:
 	@go build -o ${BINARY}
 
-dev: build
-	@mkdir -p ~/.packer.d/plugins/
-	@mv ${BINARY} ~/.packer.d/plugins/${BINARY}
+dev:
+	go build -ldflags="-X '${BINARY}/version.VersionPrerelease=dev'" -o ${BINARY}
+	packer plugins install --path ${BINARY} "github.com/cirruslabs/$(NAME)"
 
 test:
 	@go test -race -count $(COUNT) $(TEST) -timeout=3m

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "1.2.0"
+	Version = "1.10.0"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
With modern Packer, and Packer templates with required_plugins sections, the plugins need to follow a specific folder structure and also come with a sha256 hash of the plugin.

By using `packer plugins install --path` we can let Packer deal with the specifics of installing a plugin from disk instead of from a repository.