### PR TITLE
Avoid duplicated logging by TartExec

### DIFF
--- a/builder/tart/helpers.go
+++ b/builder/tart/helpers.go
@@ -25,14 +25,13 @@ func PathInTartHome(elem ...string) string {
 }
 
 func TartExec(ctx context.Context, ui packer.Ui, args ...string) (string, error) {
-
-	log.Printf("Executing tart: %#v", args)
-
 	cmd := exec.CommandContext(ctx, tartCommand, args...)
 
 	if ui != nil {
 		return "", localexec.RunAndStream(cmd, ui, []string{})
 	} else {
+		log.Printf("Executing tart: %#v", args)
+
 		var out bytes.Buffer
 		cmd.Stdout = &out
 		cmd.Stderr = &out


### PR DESCRIPTION
localexec.RunAndStream does its own logging of the command and arguments, so we only need to do so ourselves if we're running the command manually.