### PR TITLE
.github/workflows/release.yml: use Golang 1.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.22
       - name: Describe plugin
         id: plugin_describe
         run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module packer-plugin-tart
 
-go 1.21
+go 1.22
 
 toolchain go1.22.1
 


### PR DESCRIPTION
To prevent the build from failing: https://github.com/cirruslabs/packer-plugin-tart/actions/runs/8544633665/job/23411110919.