### PR TITLE
Generate plugin version at build time based on git describe

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 env:
   - CGO_ENABLED=0
+  - API_VERSION={{ if index .Env "API_VERSION"  }}{{ .Env.API_VERSION }}{{ else }}x5.0{{ end }}
+
 before:
   hooks:
     # We strongly recommend running tests to catch any regression before release.
@@ -16,13 +18,15 @@ builds:
     flags:
       - -trimpath #removes all file system paths from the compiled executable
     ldflags:
-      - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
+      - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}}'
     goos:
       - darwin
     goarch:
       - arm64
       - amd64
     binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
+snapshot:
+  name_template: "{{ if eq .Summary .Tag }}{{ .Version }}{{ else }}{{ incpatch .Version }}-dev{{ end }}"
 archives:
 - format: zip
   files:

--- a/version/version.go
+++ b/version/version.go
@@ -6,14 +6,9 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "1.10.0"
-
-	// VersionPrerelease is A pre-release marker for the Version. If this is ""
-	// (empty string) then it means that it is a final release. Otherwise, this
-	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	Version = "" // Will be set when building
 
 	// PluginVersion is used by the plugin set to allow Packer to recognize
 	// what version this plugin is.
-	PluginVersion = version.NewPluginVersion(Version, VersionPrerelease, "")
+	PluginVersion = version.NewRawVersion(Version)
 )


### PR DESCRIPTION
The go-gitver package looks at the git describe output and resolves a version based on that.

If the git describe is a plain tag, the resulting plugin version matches the tag.

If there are commits on top of the most recent tag, or the working directory is dirty, the resulting plugin version is the latest plugin version with the patch version bumped, and the "dev" suffix added.

The same logic has been applied to the goreleaser file, so that the releasing logic can be tested with --snapshot