### PR TITLE
Docs: update instructions on the Packer website and use newer version as an example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then, run [`packer init`](https://www.packer.io/docs/commands/init).
 packer {
   required_plugins {
     tart = {
-      version = ">= 0.6.0"
+      version = ">= 1.11.1"
       source  = "github.com/cirruslabs/tart"
     }
   }

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,8 @@ To install this plugin, copy and paste this code into your Packer configuration,
 ```hcl
 packer {
   required_plugins {
-    gridscale = {
-      version = ">= 1.6.1"
+    tart = {
+      version = ">= 1.11.1"
       source  = "github.com/cirruslabs/tart"
     }
   }


### PR DESCRIPTION
Hi!
I've fixed the typo on the `https://developer.hashicorp.com/packer/integrations/cirruslabs/tart`:

<details>
<summary>Screenshot:</summary>

![screenshot](https://cdn.weblab.pro/0eykj.png)

</details>

Also, I've updated the example versions of the plugin in the docs: `0.6.0 => 1.11.1`