### PR TITLE
$ make generate

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -15,8 +15,8 @@ To install this plugin, copy and paste this code into your Packer configuration,
 ```hcl
 packer {
   required_plugins {
-    gridscale = {
-      version = ">= 1.6.1"
+    tart = {
+      version = ">= 1.11.1"
       source  = "github.com/cirruslabs/tart"
     }
   }


### PR DESCRIPTION
I'm not sure why the `ensure-docs-compiled.yaml` workflow didn't run on https://github.com/cirruslabs/packer-plugin-tart/pull/150, but we have to do this every time we change the docs now.