### PR TITLE
(*stepDiskFilePrepare).Run(): add a missing fallthrough statement

### DIFF
--- a/builder/tart/step_disk_file_prepare.go
+++ b/builder/tart/step_disk_file_prepare.go
@@ -36,6 +36,7 @@ func (s *stepDiskFilePrepare) Run(ctx context.Context, state multistep.StateBag)
 
 	switch config.RecoveryPartition {
 	case "":
+		fallthrough
 	case "delete":
 		if err := recoverypartition.Delete(diskImagePath, ui, state); err != nil {
 			ui.Error(fmt.Sprintf("Failed to delete the recovery partition: %v", err))


### PR DESCRIPTION
Resolves https://github.com/cirruslabs/packer-plugin-tart/issues/149.