### PR TITLE
Use SSH key generation step

### DIFF
--- a/builder/tart/builder.go
+++ b/builder/tart/builder.go
@@ -129,6 +129,10 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 
 	if !b.config.Recovery && communicatorConfigured {
 		steps = append(steps,
+			&communicator.StepSSHKeyGen{
+				CommConf:            &b.config.CommunicatorConfig,
+				SSHTemporaryKeyPair: b.config.CommunicatorConfig.SSH.SSHTemporaryKeyPair,
+			},
 			&communicator.StepConnect{
 				Config: &b.config.CommunicatorConfig,
 				Host: func(state multistep.StateBag) (string, error) {


### PR DESCRIPTION
To load the `ssh_private_key_file` when specified.

Resolves https://github.com/cirruslabs/packer-plugin-tart/issues/162.