### PR TITLE
Introduce "always_pull" option

### DIFF
--- a/.web-docs/components/builder/tart/README.md
+++ b/.web-docs/components/builder/tart/README.md
@@ -46,6 +46,7 @@ For more advanced examples, please refer to the [`example/` directory](https://g
 #### Optional:
 
 - `allow_insecure` (boolean) — When cloning the image, connect to the OCI registry via an insecure HTTP protocol.
+- `always_pull` (boolean) — Always do a `tart pull` before `tart clone` to have an up-to-date image before building.
 - `pull_concurrency` (boolean) — Amount of layers to pull concurrently from an OCI registry when pulling the image. Default is 4 for Tart 2.0.0+.
 - `cpu_count` (number) - Amount of virtual CPUs to use for the new VM. Overrides `tart create` default value when using `from_ipsw` and `from_iso` and VM settings when using `vm_base_name`.
 - `create_grace_time` (duration string | ex: "1h5m2s") — Time to wait after finishing the installation process. Can be used to work around the issue when Virtualization.Framework's installation process is still running in the background for some time after `tart create` had already finished.

--- a/builder/tart/builder.go
+++ b/builder/tart/builder.go
@@ -32,6 +32,7 @@ type Config struct {
 	VMBaseName      string   `mapstructure:"vm_base_name"`
 	VMName          string   `mapstructure:"vm_name"`
 	AllowInsecure   bool     `mapstructure:"allow_insecure"`
+	AlwaysPull      bool     `mapstructure:"always_pull"`
 	PullConcurrency uint16   `mapstructure:"pull_concurrency"`
 
 	CpuCount          uint8         `mapstructure:"cpu_count"`

--- a/builder/tart/builder.hcl2spec.go
+++ b/builder/tart/builder.hcl2spec.go
@@ -83,6 +83,7 @@ type FlatConfig struct {
 	VMBaseName                *string           `mapstructure:"vm_base_name" cty:"vm_base_name" hcl:"vm_base_name"`
 	VMName                    *string           `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	AllowInsecure             *bool             `mapstructure:"allow_insecure" cty:"allow_insecure" hcl:"allow_insecure"`
+	AlwaysPull                *bool             `mapstructure:"always_pull" cty:"always_pull" hcl:"always_pull"`
 	PullConcurrency           *uint16           `mapstructure:"pull_concurrency" cty:"pull_concurrency" hcl:"pull_concurrency"`
 	CpuCount                  *uint8            `mapstructure:"cpu_count" cty:"cpu_count" hcl:"cpu_count"`
 	CreateGraceTime           *string           `mapstructure:"create_grace_time" cty:"create_grace_time" hcl:"create_grace_time"`
@@ -182,6 +183,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_base_name":                 &hcldec.AttrSpec{Name: "vm_base_name", Type: cty.String, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"allow_insecure":               &hcldec.AttrSpec{Name: "allow_insecure", Type: cty.Bool, Required: false},
+		"always_pull":                  &hcldec.AttrSpec{Name: "always_pull", Type: cty.Bool, Required: false},
 		"pull_concurrency":             &hcldec.AttrSpec{Name: "pull_concurrency", Type: cty.Number, Required: false},
 		"cpu_count":                    &hcldec.AttrSpec{Name: "cpu_count", Type: cty.Number, Required: false},
 		"create_grace_time":            &hcldec.AttrSpec{Name: "create_grace_time", Type: cty.String, Required: false},

--- a/docs/builders/tart.mdx
+++ b/docs/builders/tart.mdx
@@ -55,6 +55,7 @@ For more advanced examples, please refer to the [`example/` directory](https://g
 #### Optional:
 
 - `allow_insecure` (boolean) — When cloning the image, connect to the OCI registry via an insecure HTTP protocol.
+- `always_pull` (boolean) — Always do a `tart pull` before `tart clone` to have an up-to-date image before building.
 - `pull_concurrency` (boolean) — Amount of layers to pull concurrently from an OCI registry when pulling the image. Default is 4 for Tart 2.0.0+.
 - `cpu_count` (number) - Amount of virtual CPUs to use for the new VM. Overrides `tart create` default value when using `from_ipsw` and `from_iso` and VM settings when using `vm_base_name`.
 - `create_grace_time` (duration string | ex: "1h5m2s") — Time to wait after finishing the installation process. Can be used to work around the issue when Virtualization.Framework's installation process is still running in the background for some time after `tart create` had already finished.


### PR DESCRIPTION
To always have an up-to-date image before building.

Resolves https://github.com/cirruslabs/packer-plugin-tart/issues/171.