### PR TITLE
Set statekey.DiskChanged only when "delete" or "relocate" are used

### DIFF
--- a/builder/tart/builder.go
+++ b/builder/tart/builder.go
@@ -99,6 +99,12 @@ func (b *Builder) Prepare(raws ...interface{}) (generatedVars []string, warnings
 		return nil, nil, fmt.Errorf("disk_format must be either 'raw' or 'asif', got '%s'", b.config.DiskFormat)
 	}
 
+	if b.config.DiskFormat == "asif" && b.config.RecoveryPartition != "keep" {
+		return nil, nil, fmt.Errorf("please set the \"recovery_partition\" " +
+			"to \"keep\", as \"delete\" (the default) and \"relocate\" are not supported " +
+			"for ASIF disks")
+	}
+
 	if errs := b.config.CommunicatorConfig.Prepare(&b.config.ctx); len(errs) != 0 {
 		return nil, nil, packer.MultiErrorAppend(nil, errs...)
 	}

--- a/builder/tart/step_disk_file_prepare.go
+++ b/builder/tart/step_disk_file_prepare.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"packer-plugin-tart/builder/tart/recoverypartition"
-	"packer-plugin-tart/builder/tart/statekey"
 	"strconv"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -22,22 +21,11 @@ func (s *stepDiskFilePrepare) Run(ctx context.Context, state multistep.StateBag)
 	diskImagePath := PathInTartHome("vms", config.VMName, "disk.img")
 
 	if config.DiskSizeGb > 0 {
-		vmInfo, err := TartVMInfo(ctx, nil, config.VMName)
-		if err != nil {
-			state.Put("error", fmt.Errorf("Failed to retrieve VM's information: %w", err))
-
-			return multistep.ActionHalt
-		}
-
-		_, err = TartExec(ctx, ui, "set", "--disk-size", strconv.Itoa(int(config.DiskSizeGb)), config.VMName)
+		_, err := TartExec(ctx, ui, "set", "--disk-size", strconv.Itoa(int(config.DiskSizeGb)), config.VMName)
 		if err != nil {
 			state.Put("error", fmt.Errorf("Failed to resize a VM: %w", err))
 
 			return multistep.ActionHalt
-		}
-
-		if int64(config.DiskSizeGb) != vmInfo.Disk {
-			state.Put(statekey.DiskChanged, true)
 		}
 	}
 


### PR DESCRIPTION
We already set this state key in `Delete()`:

https://github.com/cirruslabs/packer-plugin-tart/blob/20106e644a9e2dab032c40af6f77e26b9b87b29b/builder/tart/recoverypartition/delete.go#L71

...and in `Relocate()`:

https://github.com/cirruslabs/packer-plugin-tart/blob/216df5b67f2fcdd9c7963b0184e7ebe3d063c4f8/builder/tart/recoverypartition/relocate.go#L92

Also error out when `disk_format` is `asif`, but `recovery_partition` value is something other than `keep`.

Resolves https://github.com/cirruslabs/packer-plugin-tart/issues/207, resolves https://github.com/cirruslabs/macos-image-templates/issues/318.