### PR TITLE
Add bootcommand mappings for left/right command and option keys

### DIFF
--- a/.web-docs/components/builder/tart/README.md
+++ b/.web-docs/components/builder/tart/README.md
@@ -272,8 +272,10 @@ For more examples of various boot commands, see the sample projects from our
 <!-- End of code generated from the comments of the BootConfig struct in bootcommand/config.go; -->
 
 
-Additionally, Tart builder supports the following custom commands that utilize computer vision:
+Additionally, Tart builder supports the following custom commands:
 
+* `<leftCommand> <rightCommand>` - Simulates pressing the ⌘ key.
+* `<leftOption> <rightOption>` - Simulates pressing the ⌥ key.
 * `<wait 'string'>` — waits for the given string to appear in the VM's screen output
     * the `string` can be a simple word, a sentence or a regular expression
     * alternative to `<waitXX>` command with large values

--- a/builder/tart/step_run.go
+++ b/builder/tart/step_run.go
@@ -266,6 +266,20 @@ func typeBootCommandOverVNC(
 	command = stringClickRegex.ReplaceAllString(command,
 		fmt.Sprintf(`%c${1}%c`, ClickStringStart, ClickStringEnd))
 
+	// Waiting for https://github.com/hashicorp/packer-plugin-sdk/pull/293
+	leftCommandRegex := regexp.MustCompile(`<leftCommand(On|Off)?>`)
+	command = leftCommandRegex.ReplaceAllString(command,
+		fmt.Sprintf(`<%c${1}>`, LeftCommand))
+	rightCommandRegex := regexp.MustCompile(`<rightCommand(On|Off)?>`)
+	command = rightCommandRegex.ReplaceAllString(command,
+		fmt.Sprintf(`<%c${1}>`, RightCommand))
+	leftOptionRegex := regexp.MustCompile(`<leftOption(On|Off)?>`)
+	command = leftOptionRegex.ReplaceAllString(command,
+		fmt.Sprintf(`<%c${1}>`, LeftOption))
+	rightOptionRegex := regexp.MustCompile(`<rightOption(On|Off)?>`)
+	command = rightOptionRegex.ReplaceAllString(command,
+		fmt.Sprintf(`<%c${1}>`, RightOption))
+
 	seq, err := bootcommand.GenerateExpressionSequence(command)
 	if err != nil {
 		err := fmt.Errorf("Failed to parse the boot command: %s", err)

--- a/builder/tart/vnc.go
+++ b/builder/tart/vnc.go
@@ -77,6 +77,11 @@ const (
 
 	ClickStringStart rune = 0xE0002
 	ClickStringEnd   rune = 0xE0003
+
+	LeftCommand  rune = 0xFFE9
+	RightCommand rune = 0xFFEA
+	LeftOption   rune = 0xFFE7
+	RightOption  rune = 0xFFE8
 )
 
 func (d *customDriver) SendKey(key rune, action bootcommand.KeyAction) error {

--- a/docs/builders/tart.mdx
+++ b/docs/builders/tart.mdx
@@ -90,8 +90,10 @@ For more advanced examples, please refer to the [`example/` directory](https://g
 
 @include 'packer-plugin-sdk/bootcommand/BootConfig.mdx'
 
-Additionally, Tart builder supports the following custom commands that utilize computer vision:
+Additionally, Tart builder supports the following custom commands:
 
+* `<leftCommand> <rightCommand>` - Simulates pressing the ⌘ key.
+* `<leftOption> <rightOption>` - Simulates pressing the ⌥ key.
 * `<wait 'string'>` — waits for the given string to appear in the VM's screen output
     * the `string` can be a simple word, a sentence or a regular expression
     * alternative to `<waitXX>` command with large values


### PR DESCRIPTION
Awaiting the merge of the feature in the upstream Packer SDK repo, let's override the plugin SDK with a branch that has the feature.

See hashicorp/packer-plugin-sdk#293