### PR TITLE
Allow ssh in recovery mode

### DIFF
--- a/builder/tart/builder.go
+++ b/builder/tart/builder.go
@@ -145,7 +145,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		steps = append(steps, new(stepRun))
 	}
 
-	if !b.config.Recovery && communicatorConfigured {
+	if communicatorConfigured {
 		steps = append(steps,
 			&communicator.StepSSHKeyGen{
 				CommConf:            &b.config.CommunicatorConfig,


### PR DESCRIPTION

    Recovery mode doesn't usually support SSH, but there may
    be cases where the boot commands result in rebooting into
    non-recovery mode, with SSH available, in which case we
    want to allow SSH-based provisioning.

    By defaulting the communicator to "none" in Rescue mode,
    we avoid waiting for SSH unnecessarily, while allowing
    users to override the communicator to "ssh" when needed.