### PR TITLE
Specify GPT partition indices in tests

### DIFF
--- a/builder/tart/recoverypartition/delete_test.go
+++ b/builder/tart/recoverypartition/delete_test.go
@@ -1,15 +1,16 @@
 package recoverypartition_test
 
 import (
+	"os"
+	"packer-plugin-tart/builder/tart/recoverypartition"
+	"path/filepath"
+	"testing"
+
 	"github.com/diskfs/go-diskfs"
 	"github.com/diskfs/go-diskfs/partition/gpt"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/stretchr/testify/require"
-	"os"
-	"packer-plugin-tart/builder/tart/recoverypartition"
-	"path/filepath"
-	"testing"
 )
 
 func TestDelete(t *testing.T) {
@@ -29,12 +30,14 @@ func TestDelete(t *testing.T) {
 	const partitionSizeBytes = partitionSizeSectors * sectorSizeBytes
 
 	firstPartition := &gpt.Partition{
+		Index: 1,
 		Start: 34,
 		Size:  partitionSizeBytes,
 		Type:  gpt.AppleAPFS,
 		Name:  "Doesn't matter",
 	}
 	secondPartition := &gpt.Partition{
+		Index: 2,
 		Start: 34 + partitionSizeSectors,
 		Size:  partitionSizeBytes,
 		Type:  gpt.AppleAPFS,

--- a/builder/tart/recoverypartition/relocate_test.go
+++ b/builder/tart/recoverypartition/relocate_test.go
@@ -3,16 +3,17 @@ package recoverypartition_test
 import (
 	"bufio"
 	"bytes"
-	"github.com/diskfs/go-diskfs"
-	"github.com/diskfs/go-diskfs/partition/gpt"
-	"github.com/hashicorp/packer-plugin-sdk/multistep"
-	"github.com/hashicorp/packer-plugin-sdk/packer"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"packer-plugin-tart/builder/tart/recoverypartition"
 	"path/filepath"
 	"testing"
+
+	"github.com/diskfs/go-diskfs"
+	"github.com/diskfs/go-diskfs/partition/gpt"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRelocate(t *testing.T) {
@@ -38,12 +39,14 @@ func TestRelocate(t *testing.T) {
 
 	// Partition our disk as GPT with a macOS recovery partition
 	firstPartition := &gpt.Partition{
+		Index: 1,
 		Start: 34,
 		Size:  partitionSizeBytes,
 		Type:  gpt.AppleAPFS,
 		Name:  "Doesn't matter",
 	}
 	secondPartition := &gpt.Partition{
+		Index: 2,
 		Start: 34 + partitionSizeSectors,
 		Size:  partitionSizeBytes,
 		Type:  gpt.AppleAPFS,


### PR DESCRIPTION
[New version of `github.com/diskfs/go-diskfs`](https://github.com/cirruslabs/packer-plugin-tart/pull/227) requires the indices to be present.