### PR TITLE
Release VNC pointer after OCR click

### DIFF
--- a/builder/tart/vnc.go
+++ b/builder/tart/vnc.go
@@ -135,6 +135,10 @@ func (d *customDriver) SendKey(key rune, action bootcommand.KeyAction) error {
 		if err := d.vncClient.PointerEvent(vnc.ButtonLeft, uint16(centerX), uint16(centerY)); err != nil {
 			return err
 		}
+		time.Sleep(100 * time.Millisecond)
+		if err := d.vncClient.PointerEvent(0, uint16(centerX), uint16(centerY)); err != nil {
+			return err
+		}
 	default:
 		switch {
 		case d.waitString.Cap() > 0:


### PR DESCRIPTION
## Summary

`<click ...>` currently sends a left-button VNC pointer event but never sends the matching release event. This PR sends `PointerEvent(0, x, y)` after a short delay so the generated input is a complete click.

## Why

VNC pointer events carry the current button mask. Sending only `vnc.ButtonLeft` leaves the button logically pressed, which can make macOS Setup Assistant focus or select text instead of activating a button. Releasing the mask after a brief press matches normal mouse click behavior.

## Validation

- `go test ./...`
- Verified with macOS Setup Assistant OCR boot commands that previously stalled after finding the target text.